### PR TITLE
Init nixosModule, add new options, allow NvChad to be run with `nix-run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Enables NvChad
 ### `defaultEditor`
 Sets your `$EDITOR` variable to be NvChad
 
-### `customConfig`
-Adds the specified custom folder with your configurations, e.g `chadrc.lua` it can be as many files as you need.
+### `otherConfigs`
+Folder with other configuration files that you wish to be added to `lua/custom`
 
 ### `chadrcContents` and `initLuaContents`
 Define the content of `charc.lua` and/or `init.lua`. This can either be lines, or you can import your files into the lines with `${builtins.readFile ./some-path}`

--- a/README.md
+++ b/README.md
@@ -46,4 +46,8 @@ Enables NvChad
 Sets your `$EDITOR` variable to be NvChad
 
 ### `customConfig`
-Adds the specified custom folder with your configurations, e.g `chadrc.lua`
+Adds the specified custom folder with your configurations, e.g `chadrc.lua` it can be as many files as you need.
+
+### `chadrcContents` and `initLuaContents`
+Define the content of `charc.lua` and/or `init.lua`. This can either be lines, or you can import your files into the lines with `${builtins.readFile ./some-path}`
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # NvChad Nix/NixOS support
 This flake aims to support the Nix Package manager and the NixOS system.
 
+# Want to test NvChad out?
+Just use this command on flakes enabled system:
+
+``` bash
+nix run "github:NvChad/nix"
+```
+
 ## How to use it 
 Add the url of the repo to your `inputs`
 

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 { lib
 , config
-, self
 , pkgs
 , ...
 }:
@@ -36,6 +35,22 @@ in
             Folder with chadrc.lua and other custom configuration
           '';
         };
+
+    chadrcContents = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      description = ''
+        Contents to go into the chadrc.lua file
+      '';
+    };
+
+    initLuaContents = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      description = ''
+        Contents to go into the init.lua file
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -45,6 +60,14 @@ in
     xdg.configFile."nvim/lua/custom" = mkIf (cfg.customConfig != null) {
       source = cfg.customConfig;
       recursive = true;
+    };
+
+    xdg.configFile."nvim/lua/custom/chadrc.lua" = mkIf (cfg.chadrcContents != null) {
+      text = cfg.chadrcContents;
+    };
+
+    xdg.configFile."nvim/lua/custom/init.lua" = mkIf (cfg.initLuaContents != null) {
+      text = cfg.initLuaContents;
     };
 
     xdg.configFile."nvim/lua" = {

--- a/default.nix
+++ b/default.nix
@@ -71,12 +71,12 @@ in
     };
 
     xdg.configFile."nvim/lua" = {
-      source = "${NvChad}/lua";
+      source = "${NvChad}/.config/nvim/lua";
       recursive = true;
     };
 
     xdg.configFile."nvim/init.lua" = {
-      source = "${NvChad}/init.lua";
+      source = "${NvChad}/.config/nvim/init.lua";
     };
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -25,14 +25,14 @@ in
       '';
     };
 
-    customConfig =
+    otherConfigs =
       mkOption
         {
           type = types.nullOr types.path;
           example = "./config";
           default = null;
           description = ''
-            Folder with chadrc.lua and other custom configuration
+            Folder with other configuration files that you wish to be added to `lua/custom`
           '';
         };
 
@@ -57,8 +57,8 @@ in
     programs.neovim.enable = true;
     programs.neovim.defaultEditor = mkIf cfg.defaultEditor true;
 
-    xdg.configFile."nvim/lua/custom" = mkIf (cfg.customConfig != null) {
-      source = cfg.customConfig;
+    xdg.configFile."nvim/lua/custom" = mkIf (cfg.otherConfigs != null) {
+      source = cfg.otherConfigs;
       recursive = true;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/23.11";
   };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, self, ... }:
     let
       forAllSystems = function:
         nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ] (system: function nixpkgs.legacyPackages.${system});

--- a/flake.nix
+++ b/flake.nix
@@ -18,5 +18,9 @@
       homeManagerModules = {
         default = import ./default.nix;
       };
+
+      nixosModules = {
+        default = import ./default.nix;
+      };
     };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,17 +1,26 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, lib, makeWrapper, neovim }:
 stdenv.mkDerivation rec {
   version = "v2.0";
   name = "NvChad-${version}";
+
   src = fetchFromGitHub {
     owner = "NvChad";
-    leaveDotGit = true;
     repo = "NvChad";
     rev = "0dcd8a91b69f1fc0fe7064bd404b5390c1c164c5";
     sha256 = "N+Ftw/Poylv2+9QKoteDbKzjB5aOy7NjDRICEmSvsAw=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+  runtimeDeps = [ neovim ];
+
   installPhase = ''
-    mkdir -p $out
-    cp -R * $out
+    mkdir -p $out/.config/nvim
+    mkdir -p $out/bin
+    cp -R * $out/.config/nvim/
+    echo "XDG_CONFIG_HOME=$out/.config nvim" >> $out/bin/NvChad-${version}
+    chmod +x $out/bin/NvChad-${version}
+
+    wrapProgram $out/bin/NvChad-${version} \
+    --prefix PATH : ${lib.makeBinPath runtimeDeps}
   '';
 }


### PR DESCRIPTION
This PR adds the following changes:

- Renames the `customConfig` option to `otherConfigs`
- Adds the options to manage `chadrc.lua` and `init.lua` with nix
- Allows NvChad to be run from any machine with nix without installing it in `~/.config/nvim/`