### PR TITLE
Hotfix: option default neovim package

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Somewhere in your `home.nix` or a separate module
 
 if false ignore this module when build new generation
 
-##### neovim
+##### neovim (optional)
 
 `pkgs.neovim`
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -4,10 +4,8 @@
 
 { config, pkgs, lib, ... }: let
   cfg = config.programs.nvchad;
-  extraPackages = [];
-  neovim = cfg.neovim;
   nvchad = pkgs.callPackage ./nvchad.nix {
-    inherit neovim;
+    neovim = cfg.neovim;
     extraPackages = cfg.extraPackages;
     extraConfig = cfg.extraConfig;
   };
@@ -16,7 +14,7 @@
     enable = mkEnableOption "Enable NvChad";
     extraPackages = mkOption {
       type = types.listOf types.package;
-      default = extraPackages;
+      default = [ ];
       description = ''
         List of additional packages available for NvChad as runtime dependencies
         NvChad extensions assume that the libraries it need
@@ -38,7 +36,7 @@
     };
     neovim = mkOption {
       type = types.package;
-      default = neovim;
+      default = pkgs.neovim;
       defaultText = literalExpression "pkgs.neovim";
       description = "neovim package for use under nvchad wrapper";
     };


### PR DESCRIPTION
The fix #3  makes the `neovim` option required.
I slightly changed the logic of how the package is passed to the `callPackage` function.
Now if the user passes his package, it will go into the function normally as intended.
If the user has not passed anything, pkgs.neovim from the nix cache will be used.

I indicated in README.md that the `neovim` option is optional.